### PR TITLE
"Value" not sent up when tracking events

### DIFF
--- a/GoogleAnalyticsTracker/Tracker.cs
+++ b/GoogleAnalyticsTracker/Tracker.cs
@@ -130,7 +130,7 @@ namespace GoogleAnalyticsTracker
             parameters.Add("utmt", "event");
 
             var utme = _utmeGenerator.Generate();
-            parameters.Add("utme", string.Format("5({0}*{1}*{2})(3)", category, action, label, value) + utme);
+            parameters.Add("utme", string.Format("5({0}*{1}*{2})({3})", category, action, label, value) + utme);
 
             parameters.Add("utmcs", CharacterSet);
             parameters.Add("utmul", Language);


### PR DESCRIPTION
Fix the format string for the utme query string parameter so the "value" is sent up properly (Issue #5).
