### PR TITLE
To prevent Exception in Task.Finalize() when closing WP app

### DIFF
--- a/GoogleAnalyticsTracker/Tracker.cs
+++ b/GoogleAnalyticsTracker/Tracker.cs
@@ -162,7 +162,7 @@ namespace GoogleAnalyticsTracker
                                              }
                                              finally
                                              {
-                                                 if (task.Result != null)
+                                                 if (!task.IsFaulted && task.Result != null)
                                                  {
                                                      var disposableResult = task.Result as IDisposable;
                                                      if (disposableResult != null)


### PR DESCRIPTION
Wrapping the RequestUrlAsync in try-catch-block isn't enough apparently. In my case an exception is thrown in the Task.Factory.FromAsync call - specifically in the request.EndGetResponse - call. In the finally block during the ConinueWith Func-execution another exception is raised, when acccessing the t.Result property when the task has been faulted.

This is why I am adding the check, whether the task has been  faulted. 
