### PR TITLE
Removed Newtonsoft.Json dependency

### DIFF
--- a/GoogleAnalyticsTracker/Web/CookieBasedAnalyticsSession.cs
+++ b/GoogleAnalyticsTracker/Web/CookieBasedAnalyticsSession.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Web;
-using Newtonsoft.Json;
 
 namespace GoogleAnalyticsTracker.Web
 {
@@ -23,25 +22,28 @@ namespace GoogleAnalyticsTracker.Web
 
         protected override string GetUniqueVisitorId()
         {
-            if (string.IsNullOrEmpty(GetHttpContext().GetDeserializedCookieValue<string>(StorageKeyUniqueId)))
+            if (string.IsNullOrEmpty(GetHttpContext().GetDeserializedCookieValue(StorageKeyUniqueId)))
             {
                 GetHttpContext().SetSerializedCookieValue(StorageKeyUniqueId, base.GetUniqueVisitorId());
             }
-            return GetHttpContext().GetDeserializedCookieValue<string>(StorageKeyUniqueId);
+            return GetHttpContext().GetDeserializedCookieValue(StorageKeyUniqueId);
         }
 
         protected override int GetFirstVisitTime()
         {
-            if (GetHttpContext().GetDeserializedCookieValue<int>(StorageKeyFirstVisitTime) == 0)
+            int firstVisitTime = 0;
+            if (int.TryParse(GetHttpContext().GetDeserializedCookieValue(StorageKeyFirstVisitTime), out firstVisitTime) && firstVisitTime == 0)
             {
-                GetHttpContext().SetSerializedCookieValue(StorageKeyFirstVisitTime, base.GetFirstVisitTime());
+                firstVisitTime = base.GetFirstVisitTime();
+                GetHttpContext().SetSerializedCookieValue(StorageKeyFirstVisitTime, firstVisitTime);
             }
-            return GetHttpContext().GetDeserializedCookieValue<int>(StorageKeyFirstVisitTime);
+            return firstVisitTime;
         }
 
         protected override int GetPreviousVisitTime()
         {
-            var previousVisitTime = GetHttpContext().GetDeserializedCookieValue<int>(StorageKeyPreviousVisitTime);
+            int previousVisitTime = 0;
+            int.TryParse(GetHttpContext().GetDeserializedCookieValue(StorageKeyPreviousVisitTime), out previousVisitTime);
             GetHttpContext().SetSerializedCookieValue(StorageKeyPreviousVisitTime, GetCurrentVisitTime());
 
             if (previousVisitTime == 0)
@@ -54,7 +56,8 @@ namespace GoogleAnalyticsTracker.Web
 
         protected override int GetSessionCount()
         {
-            var sessionCount = GetHttpContext().GetDeserializedCookieValue<int>(StorageKeySessionCount);
+            int sessionCount = 0;
+            int.TryParse(GetHttpContext().GetDeserializedCookieValue(StorageKeySessionCount), out sessionCount);
             GetHttpContext().SetSerializedCookieValue(StorageKeySessionCount, ++sessionCount);
             return sessionCount;
         }

--- a/GoogleAnalyticsTracker/Web/HttpContextBaseExtensions.cs
+++ b/GoogleAnalyticsTracker/Web/HttpContextBaseExtensions.cs
@@ -1,28 +1,35 @@
 using System.Web;
-using Newtonsoft.Json;
 
 namespace GoogleAnalyticsTracker.Web
 {
     public static class HttpContextBaseExtensions
     {
-        public static T GetDeserializedCookieValue<T>(this HttpContextBase context, string key)
+        public static string GetDeserializedCookieValue(this HttpContextBase context, string key)
         {
             if (context != null)
             {
                 var cookie = context.Request.Cookies.Get(key);
-                if (cookie != null)
+                if (cookie != null && !string.IsNullOrWhiteSpace(cookie.Value))
                 {
-                    return JsonConvert.DeserializeObject<T>(cookie.Value);
+                    return cookie.Value;
                 }
             }
-            return default(T);
+            return null;
         }
 
-        public static void SetSerializedCookieValue(this HttpContextBase context, string key, object value)
+        public static void SetSerializedCookieValue(this HttpContextBase context, string key, string value)
         {
             if (context != null)
             {
-                context.Response.Cookies.Add(new HttpCookie(key, JsonConvert.SerializeObject(value)));
+                context.Response.Cookies.Add(new HttpCookie(key, value));
+            }
+        }
+
+        public static void SetSerializedCookieValue(this HttpContextBase context, string key, int value)
+        {
+            if (context != null)
+            {
+                context.Response.Cookies.Add(new HttpCookie(key, value.ToString()));
             }
         }
     }

--- a/GoogleAnalyticsTracker/packages.config
+++ b/GoogleAnalyticsTracker/packages.config
@@ -1,4 +1,2 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="Newtonsoft.Json" version="5.0.5" targetFramework="net40" />
-</packages>
+<packages></packages>


### PR DESCRIPTION
Removed the need for the dependency, since only a string and 3 ints
needed to be stored in cookies and the ints can be easily parsed using
builtin tryparse. If anyone still needs custom object they can serialize
them into strings outside of this lib. Opened issue #43
