### PR TITLE
Web Api 2 improvements

### DIFF
--- a/GoogleAnalyticsTracker.WebAPI2/GoogleAnalyticsTracker.WebAPI2.csproj
+++ b/GoogleAnalyticsTracker.WebAPI2/GoogleAnalyticsTracker.WebAPI2.csproj
@@ -55,6 +55,7 @@
     <Compile Include="AsyncActionFilterAttribute.cs" />
     <Compile Include="ConfigurationHelper.cs" />
     <Compile Include="CookieBasedAnalyticsSession.cs" />
+    <Compile Include="Helpers\WebApiHelper.cs" />
     <Compile Include="HttpRequestMessageExtensions.cs" />
     <Compile Include="Interface\IRequireRequestAndResponse.cs" />
     <Compile Include="PageViewTrackerExtensions.cs" />

--- a/GoogleAnalyticsTracker.WebAPI2/Helpers/WebApiHelper.cs
+++ b/GoogleAnalyticsTracker.WebAPI2/Helpers/WebApiHelper.cs
@@ -1,0 +1,37 @@
+﻿using System.Net.Http;
+using System.Web;
+
+namespace GoogleAnalyticsTracker.WebAPI2
+{
+    internal static class WebApiHelper
+    {
+        public static HttpRequestMessage GetCurrentRequest()
+        {
+            var httpRequestMessage = HttpContext.Current.Items["MS_HttpRequestMessage"] as HttpRequestMessage;
+            return httpRequestMessage;
+        }
+
+        public static string GetClientIp(HttpRequestMessage request = null)
+        {
+            if (request == null)
+            {
+                request = GetCurrentRequest();
+            }
+
+            if (request.Properties.ContainsKey("MS_HttpContext"))
+            {
+                var userHostAddress =
+                    ((HttpContextWrapper) request.Properties["MS_HttpContext"]).Request.UserHostAddress;
+                return userHostAddress;
+            }
+
+            if (HttpContext.Current != null)
+            {
+                var userHostAddress = HttpContext.Current.Request.UserHostAddress;
+                return userHostAddress;
+            }
+
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
* Add TrackPageViewAsync extension that automatically determines the request so you don't have to specify it
* Override ip so it's always accessible (I noticed that it wasn't picking up the client ips when requests came from Windows Store apps hosted on Azure servers)