### PR TITLE
Make TrackingDomain, UserAgent and Hostname optional

### DIFF
--- a/GoogleAnalyticsTracker.Core/TrackerBase.cs
+++ b/GoogleAnalyticsTracker.Core/TrackerBase.cs
@@ -50,7 +50,7 @@ namespace GoogleAnalyticsTracker.Core
             CharacterSet = "UTF-8";
         }
 
-        private async Task<TrackingResult> RequestUrlAsync(string url, IDictionary<string, string> parameters, string userAgent = null)
+        private async Task<TrackingResult> RequestUrlAsync(string url, IDictionary<string, string> parameters, string userAgent)
         {
             // Create GET string
             var data = new StringBuilder();
@@ -67,10 +67,14 @@ namespace GoogleAnalyticsTracker.Core
             };
 
             // Determine referer URL
-            var referer = string.Format("http://{0}/", TrackingDomain);
+            string referer = null;
             if (parameters.ContainsKey("ReferralUrl"))
             {
                 referer = parameters["ReferralUrl"];
+            }
+            else if (!string.IsNullOrEmpty(TrackingDomain))
+            {
+                referer = string.Format("http://{0}/", TrackingDomain);
             }
 
             // Create request
@@ -78,8 +82,10 @@ namespace GoogleAnalyticsTracker.Core
             try
             {
                 request = (HttpWebRequest)WebRequest.Create(string.Format("{0}?{1}", url, data));                
-                request.SetHeader("Referer", referer);
-                request.SetHeader("User-Agent", userAgent ?? UserAgent);
+                if (!string.IsNullOrEmpty(referer))
+                    request.SetHeader("Referer", referer);
+                if (!string.IsNullOrEmpty(userAgent))
+                    request.SetHeader("User-Agent", userAgent);
             }
             catch (Exception ex)
             {

--- a/GoogleAnalyticsTracker.Simple/SimpleTrackerEnvironment.cs
+++ b/GoogleAnalyticsTracker.Simple/SimpleTrackerEnvironment.cs
@@ -1,6 +1,5 @@
-using System;
 using GoogleAnalyticsTracker.Core.Interface;
-using GoogleAnalyticsTracker.Core.TrackerParameters.Interface;
+using System;
 
 namespace GoogleAnalyticsTracker.Simple
 {
@@ -9,7 +8,7 @@ namespace GoogleAnalyticsTracker.Simple
         /// <summary>
         /// Create a new SimpleTrackerEnvironment.
         /// </summary>
-        /// <param name="hostname">Machine hostname, e.g. Dns.GetHostName()</param>
+        /// <param name="hostname">Machine hostname, e.g. Dns.GetHostName(). May be null.</param>
         /// <param name="osPlatform">OS platform, e.g. Environment.OSVersion.Platform.ToString()</param>
         /// <param name="osVersion">OS version, e.g. Environment.OSVersion.Version.ToString()</param>
         /// <param name="osVersionString">OS version string, e.g. Environment.OSVersion.VersionString</param>
@@ -23,7 +22,6 @@ namespace GoogleAnalyticsTracker.Simple
         /// </example>
         public SimpleTrackerEnvironment(string hostname, string osPlatform, string osVersion, string osVersionString)
         {
-            if (hostname == null) throw new ArgumentNullException(nameof(hostname));
             if (osPlatform == null) throw new ArgumentNullException(nameof(osPlatform));
             if (osVersion == null) throw new ArgumentNullException(nameof(osVersion));
             if (osVersionString == null) throw new ArgumentNullException(nameof(osVersionString));
@@ -34,10 +32,26 @@ namespace GoogleAnalyticsTracker.Simple
             OsVersionString = osVersionString;
         }
 
+        /// <summary>
+        /// Create a new SimpleTrackerEnvironment without hostname.
+        /// </summary>
+        /// <param name="osPlatform">OS platform, e.g. Environment.OSVersion.Platform.ToString()</param>
+        /// <param name="osVersion">OS version, e.g. Environment.OSVersion.Version.ToString()</param>
+        /// <param name="osVersionString">OS version string, e.g. Environment.OSVersion.VersionString</param>
+        /// <example>
+        /// var simpleTrackerEnvironment = new SimpleTrackerEnvironment(
+        ///     Environment.OSVersion.Platform.ToString(),
+        ///     Environment.OSVersion.Version.ToString(),
+        ///     Environment.OSVersion.VersionString
+        /// );
+        /// </example>
+        public SimpleTrackerEnvironment(string osPlatform, string osVersion, string osVersionString)
+            : this(null, osPlatform, osVersion, osVersionString)
+        { }
+
         public string Hostname { get; set; }
         public string OsPlatform { get; set; }
         public string OsVersion { get; set; }
         public string OsVersionString { get; set; }
-
     }
 }


### PR DESCRIPTION
Do not need to set TrackingDomain (header Referer) and Hostname. UserAgent as well just for the sake of completeness.