### PR TITLE
Add IAppTrackingParameters and ICustomDimensionParameters to IGeneral…

### DIFF
--- a/GoogleAnalyticsTracker.Core/TrackerParameters/GeneralParameters.cs
+++ b/GoogleAnalyticsTracker.Core/TrackerParameters/GeneralParameters.cs
@@ -327,12 +327,46 @@ namespace GoogleAnalyticsTracker.Core.TrackerParameters
 
         #endregion
 
+        #region Implementation of IAppTrackingParameters
+
+        /// <summary>
+        /// Specifies the application name.
+        /// <remarks>Optional</remarks>
+        /// <example>My App</example>
+        /// </summary>
+        [Beacon("an")]
+        public string ApplicationName { get; set; }
+
+        /// <summary>
+        /// Application identifier.
+        /// <remarks>Optional</remarks>
+        /// <example>com.company.app</example>
+        /// </summary>
+        [Beacon("aid")]
+        public string ApplicationId { get; set; }
+
+        /// <summary>
+        /// Specifies the application version.
+        /// <remarks>Optional</remarks>
+        /// <example>1.2</example>
+        /// </summary>
+        [Beacon("av")]
+        public string ApplicationVersion { get; set; }
+
+        /// <summary>
+        /// Application installer identifier.
+        /// <remarks>Optional</remarks>
+        /// <example>com.platform.vending</example>
+        /// </summary>
+        [Beacon("aiid")]
+        public string ApplicationInstallerId { get; set; }
+
+        #endregion
 
         #region Implementation of ICustomDimensionParameters
         /// <summary>
         /// Any custom dimensions are set here.
         /// </summary>
-
         public void SetCustomDimensions(IDictionary<int, string> customDimensions)
         {
             if (customDimensions == null || customDimensions.Count <= 0) return;

--- a/GoogleAnalyticsTracker.Core/TrackerParameters/Interface/ICustomDimensionParameters.cs
+++ b/GoogleAnalyticsTracker.Core/TrackerParameters/Interface/ICustomDimensionParameters.cs
@@ -1,7 +1,8 @@
-using System.Collections.Generic;
-
 namespace GoogleAnalyticsTracker.Core.TrackerParameters.Interface
 {
+    /// <summary>
+    /// Custom dimension parameters. Currently, 20 indices for the standard GA account is supported only.
+    /// </summary>
     public interface ICustomDimensionParameters
     {
         string CustomDimension1 { get; set; }
@@ -43,6 +44,5 @@ namespace GoogleAnalyticsTracker.Core.TrackerParameters.Interface
         string CustomDimension19 { get; set; }
 
         string CustomDimension20 { get; set; }
-
     }
 }

--- a/GoogleAnalyticsTracker.Core/TrackerParameters/Interface/IGeneralParameters.cs
+++ b/GoogleAnalyticsTracker.Core/TrackerParameters/Interface/IGeneralParameters.cs
@@ -2,7 +2,8 @@ namespace GoogleAnalyticsTracker.Core.TrackerParameters.Interface
 {
     public interface IGeneralParameters : IHitParameters, IUserParameters, ISystemInfoParameters,
                                           IContentInformationParameters,
-                                          ISessionParameters, ITrafficSourcesParameters
+                                          ISessionParameters, ITrafficSourcesParameters,
+                                          IAppTrackingParameters, ICustomDimensionParameters
     {
         /// <summary>
         /// The Protocol version. The current value is '1'. This will only change when there are changes made that are not backwards compatible.

--- a/GoogleAnalyticsTracker.Core/TrackerParameters/ScreenviewTracking.cs
+++ b/GoogleAnalyticsTracker.Core/TrackerParameters/ScreenviewTracking.cs
@@ -1,8 +1,6 @@
-using GoogleAnalyticsTracker.Core.TrackerParameters.Interface;
-
 namespace GoogleAnalyticsTracker.Core.TrackerParameters
 {
-    public class ScreenviewTracking : GeneralParameters, IAppTrackingParameters
+    public class ScreenviewTracking : GeneralParameters
     {
         #region Overrides of GeneralParameters
 
@@ -10,48 +8,12 @@ namespace GoogleAnalyticsTracker.Core.TrackerParameters
         /// The type of hit. Must be one of 'pageview', 'screenview', 'event', 'transaction', 'item', 'social', 'exception', 'timing'.
         /// <remarks>Required for all hit types</remarks>
         /// <example>HitType.Pageview</example>
-        /// </summary>  
+        /// </summary>
         public override HitType HitType
         {
             get { return HitType.Screenview; }
         }
 
-        #endregion
-
-        #region Implementation of IAppTrackingParameters
-
-        /// <summary>
-        /// Specifies the application name.
-        /// <remarks>Optional</remarks>
-        /// <example>My App</example>
-        /// </summary>
-        [Beacon("an")]
-        public string ApplicationName { get; set; }
-
-        /// <summary>
-        /// Application identifier.
-        /// <remarks>Optional</remarks>
-        /// <example>com.company.app</example>
-        /// </summary>
-        [Beacon("aid")]
-        public string ApplicationId { get; set; }
-
-        /// <summary>
-        /// Specifies the application version.
-        /// <remarks>Optional</remarks>
-        /// <example>1.2</example>
-        /// </summary>
-        [Beacon("av")]
-        public string ApplicationVersion { get; set; }
-
-        /// <summary>
-        /// Application installer identifier.
-        /// <remarks>Optional</remarks>
-        /// <example>com.platform.vending</example>
-        /// </summary>
-        [Beacon("aiid")]
-        public string ApplicationInstallerId { get; set; }
-
-        #endregion
+        #endregion Overrides of GeneralParameters
     }
 }


### PR DESCRIPTION
Partial fix of #124
The `ICustomDimensionParameters` were in the git repo, but not included in the project.
IMHO the IAppTrackingParameters the [Google doc App Tracking](https://developers.google.com/analytics/devguides/collection/protocol/v1/parameters#apptracking) says the Supported Hit Types is all.