### PR TITLE
TrackerBase change SetRequired virtual AmendParameters to let the use…

### DIFF
--- a/GoogleAnalyticsTracker.Core/TrackerBase.cs
+++ b/GoogleAnalyticsTracker.Core/TrackerBase.cs
@@ -26,7 +26,11 @@ namespace GoogleAnalyticsTracker.Core
         public bool ThrowOnErrors { get; set; }        
         public string EndpointUrl { get; set; }
 
-        /// <summary> Use HTTP GET (not recommended) instead of POST.</summary>
+        /// <summary> 
+        /// Use HTTP GET (not recommended) instead of POST.
+        /// When switched on, the <see cref="AmendParameters(TrackerParameters.Interface.IGeneralParameters)"/>
+        /// sets the <see cref="TrackerParameters.Interface.IGeneralParameters.CacheBuster"/>, too.
+        /// </summary>
         public bool UseHttpGet { get; set; }
 
         public TrackerBase(string trackingAccount, string trackingDomain, ITrackerEnvironment trackerEnvironment)

--- a/GoogleAnalyticsTracker.MVC4/PageViewTrackerExtensions.cs
+++ b/GoogleAnalyticsTracker.MVC4/PageViewTrackerExtensions.cs
@@ -17,7 +17,6 @@ namespace GoogleAnalyticsTracker.Mvc4
                 DocumentHostName = httpContext.Request.UserHostName,
                 UserLanguage = httpContext.Request.UserLanguages != null ? string.Join(";",  httpContext.Request.UserLanguages).ToLower() : null,
                 ReferralUrl = httpContext.Request.UrlReferrer != null ? httpContext.Request.UrlReferrer.ToString() : null,
-                CacheBuster = tracker.AnalyticsSession.GenerateCacheBuster()
             };
 
             return await tracker.TrackAsync(pageViewParameters);

--- a/GoogleAnalyticsTracker.MVC5/PageViewTrackerExtensions.cs
+++ b/GoogleAnalyticsTracker.MVC5/PageViewTrackerExtensions.cs
@@ -17,7 +17,6 @@ namespace GoogleAnalyticsTracker.MVC5
                 DocumentHostName = httpContext.Request.UserHostName,
                 UserLanguage = httpContext.Request.UserLanguages != null ? string.Join(";",  httpContext.Request.UserLanguages).ToLower() : null,
                 ReferralUrl = httpContext.Request.UrlReferrer != null ? httpContext.Request.UrlReferrer.ToString() : null,
-                CacheBuster = tracker.AnalyticsSession.GenerateCacheBuster()
             };
 
             return await tracker.TrackAsync(pageViewParameters);

--- a/GoogleAnalyticsTracker.Nancy/PageViewTrackerExtensions.cs
+++ b/GoogleAnalyticsTracker.Nancy/PageViewTrackerExtensions.cs
@@ -23,7 +23,6 @@ namespace GoogleAnalyticsTracker.Nancy
                 DocumentHostName = httpRequest.Url.HostName,
                 UserLanguage = httpRequest.Headers.AcceptLanguage.ToString().ToLower(),
                 ReferralUrl = httpRequest.Headers.Referrer,
-                CacheBuster = tracker.AnalyticsSession.GenerateCacheBuster()
             };
 
             return await tracker.TrackAsync(pageViewParameters);

--- a/GoogleAnalyticsTracker.Simple/EventViewTrackerExtensions.cs
+++ b/GoogleAnalyticsTracker.Simple/EventViewTrackerExtensions.cs
@@ -17,7 +17,6 @@ namespace GoogleAnalyticsTracker.Simple
                 Label = label,
                 Value = value,
                 DocumentHostName = tracker.Hostname,
-                CacheBuster = tracker.AnalyticsSession.GenerateCacheBuster()
             };
 
             eventTrackingParameters.SetCustomDimensions(customDimensions);

--- a/GoogleAnalyticsTracker.Simple/PageViewTrackerExtensions.cs
+++ b/GoogleAnalyticsTracker.Simple/PageViewTrackerExtensions.cs
@@ -14,7 +14,6 @@ namespace GoogleAnalyticsTracker.Simple
                 DocumentTitle = pageTitle,
                 DocumentLocationUrl = pageUrl,
                 DocumentHostName = tracker.Hostname,
-                CacheBuster = tracker.AnalyticsSession.GenerateCacheBuster()
             };
 
             pageViewParameters.SetCustomDimensions(customDimensions);

--- a/GoogleAnalyticsTracker.Simple/ScreenviewTrackerExtension.cs
+++ b/GoogleAnalyticsTracker.Simple/ScreenviewTrackerExtension.cs
@@ -18,7 +18,6 @@ namespace GoogleAnalyticsTracker.Simple
                 ApplicationInstallerId = appInstallerId,
                 DocumentHostName = tracker.Hostname,
                 ScreenName = screenName,
-                CacheBuster = tracker.AnalyticsSession.GenerateCacheBuster()
             };
 
             screenviewParamenters.SetCustomDimensions(customDimensions);

--- a/GoogleAnalyticsTracker.WebAPI/PageViewTrackerExtensions.cs
+++ b/GoogleAnalyticsTracker.WebAPI/PageViewTrackerExtensions.cs
@@ -17,7 +17,6 @@ namespace GoogleAnalyticsTracker.WebApi
                 DocumentHostName = httpRequest.RequestUri.Host,
                 UserLanguage = httpRequest.Headers.AcceptLanguage.ToString().ToLower(),
                 ReferralUrl = httpRequest.Headers.Referrer != null ? httpRequest.Headers.Referrer.ToString() : null,
-                CacheBuster = tracker.AnalyticsSession.GenerateCacheBuster()
             };
 
             return await tracker.TrackAsync(pageViewParameters);

--- a/GoogleAnalyticsTracker.WebAPI2/PageViewTrackerExtensions.cs
+++ b/GoogleAnalyticsTracker.WebAPI2/PageViewTrackerExtensions.cs
@@ -38,7 +38,6 @@ namespace GoogleAnalyticsTracker.WebAPI2
                 DocumentHostName = httpRequest.RequestUri.Host,
                 UserLanguage = httpRequest.Headers.AcceptLanguage.ToString().ToLower(),
                 ReferralUrl = httpRequest.Headers.Referrer != null ? httpRequest.Headers.Referrer.ToString() : null,                
-                CacheBuster = tracker.AnalyticsSession.GenerateCacheBuster(),
                 IpOverride = WebApiHelper.GetClientIp(httpRequest)
             };
 

--- a/GoogleAnalyticsTracker.WebAPI2/UserTimingExtensions.cs
+++ b/GoogleAnalyticsTracker.WebAPI2/UserTimingExtensions.cs
@@ -21,7 +21,6 @@ namespace GoogleAnalyticsTracker.WebAPI2
                 UserTimingVariable = var,
                 UserTimingTime = value,
                 UserTimingLabel = label,                
-                CacheBuster = tracker.AnalyticsSession.GenerateCacheBuster()
             };
 
             return await tracker.TrackAsync(userTimingParameters);


### PR DESCRIPTION
…r amend other params. Move CacheBuster to AmendParameters. Fix #124.

When working on #126 I have found that it would be simpler to make have some method like `TrackerBase.SetRequired` which could user override to add own default parameters instead of providing some object `DefaultParameters`. So I have renamed `SetRequired` to `AmendParameters`. This way the user has to call `base.AmendParameters` to keep the current functionality.
Another way could be to let the `SetRequired` and make `AmendParameters` beside that so that the user would not be able to change the default behaviour.