### PR TITLE
Make EventTracking.Value optional

### DIFF
--- a/GoogleAnalyticsTracker.Core/TrackerParameters/EventTracking.cs
+++ b/GoogleAnalyticsTracker.Core/TrackerParameters/EventTracking.cs
@@ -46,11 +46,10 @@ namespace GoogleAnalyticsTracker.Core.TrackerParameters
 
         /// <summary>
         /// Specifies the event value. Values must be non-negative.
-        /// <remarks>Required for event hit type</remarks>
         /// <example>55</example>
         /// </summary>
-        [Beacon("ev", true)]
-        public long Value { get; set; }
+        [Beacon("ev")]
+        public long? Value { get; set; }
 
         #endregion
     }

--- a/GoogleAnalyticsTracker.Core/TrackerParameters/Interface/IEventTrackingParameters.cs
+++ b/GoogleAnalyticsTracker.Core/TrackerParameters/Interface/IEventTrackingParameters.cs
@@ -28,6 +28,6 @@ namespace GoogleAnalyticsTracker.Core.TrackerParameters.Interface
         /// <remarks>Optional</remarks>
         /// <example>55</example>
         /// </summary>        
-        long Value { get; set; }
+        long? Value { get; set; }
     }
 }


### PR DESCRIPTION
Maybe `ulong` could do the better job, since the "ev" must be non-negative. But I do not know, if the Google supports values between `long.MaxValue` and `ulong.MaxValue`.