### PR TITLE
Remove GoogleBoolean and use bool

### DIFF
--- a/GoogleAnalyticsTracker.Core/GoogleAnalyticsTracker.Core.csproj
+++ b/GoogleAnalyticsTracker.Core/GoogleAnalyticsTracker.Core.csproj
@@ -70,7 +70,6 @@
     <Compile Include="TrackerParameters\ECommerceTransaction.cs" />
     <Compile Include="TrackerParameters\EventTracking.cs" />
     <Compile Include="TrackerParameters\GeneralParameters.cs" />
-    <Compile Include="TrackerParameters\GoogleBoolean.cs" />
     <Compile Include="TrackerParameters\HitType.cs" />
     <Compile Include="HttpWebRequestExtensions.cs" />
     <Compile Include="Interface\IAnalyticsSession.cs" />

--- a/GoogleAnalyticsTracker.Core/TrackerBase.async.cs
+++ b/GoogleAnalyticsTracker.Core/TrackerBase.async.cs
@@ -34,6 +34,12 @@ namespace GoogleAnalyticsTracker.Core
                 {
                     value = GetLowerCaseValueFromEnum(p, parameters) ?? p.GetMethod.Invoke(parameters, null);
                 }
+                else if (p.PropertyType == typeof(bool) || Nullable.GetUnderlyingType(p.PropertyType) != null)
+                {
+                    value = p.GetMethod.Invoke(parameters, null);
+                    if (value != null)
+                        value = (bool)value ? "1" : "0";
+                }
                 else
                 {
                     value = p.GetMethod.Invoke(parameters, null);

--- a/GoogleAnalyticsTracker.Core/TrackerParameters/ExceptionTracking.cs
+++ b/GoogleAnalyticsTracker.Core/TrackerParameters/ExceptionTracking.cs
@@ -25,16 +25,16 @@ namespace GoogleAnalyticsTracker.Core.TrackerParameters
         /// <remarks>Optional</remarks>
         /// <example>DatabaseError</example>
         /// </summary>   
-        [Beacon("exd", false, true)]
+        [Beacon("exd")]
         public string Description { get; set; }
 
         /// <summary>
         /// Specifies whether the exception was fatal.
-        /// <remarks>Optional</remarks>
-        /// <example>0</example>
+        /// <remarks>Optional, null value means the exception is fatal.</remarks>
+        /// <example>false</example>
         /// </summary> 
-        [Beacon("exf", false, true)] 
-        public GoogleBoolean IsFatal { get; set; }
+        [Beacon("exf")] 
+        public bool? IsFatal { get; set; }
 
         #endregion
     }

--- a/GoogleAnalyticsTracker.Core/TrackerParameters/GeneralParameters.cs
+++ b/GoogleAnalyticsTracker.Core/TrackerParameters/GeneralParameters.cs
@@ -35,8 +35,8 @@ namespace GoogleAnalyticsTracker.Core.TrackerParameters
         /// <remarks>Optional</remarks>
         /// <example>GoogleBoolean.True</example>
         /// </summary>         
-        [Beacon("aip", false, true)]
-        public GoogleBoolean? AnonymizeIp { get; set; }
+        [Beacon("aip")]
+        public bool? AnonymizeIp { get; set; }
 
         /// <summary>
         /// Used to collect offline / latent hits. 
@@ -74,8 +74,8 @@ namespace GoogleAnalyticsTracker.Core.TrackerParameters
         /// <remarks>Optional</remarks>
         /// <example>GoogleBoolean.True</example>
         /// </summary>                
-        [Beacon("ni", false, true)]
-        public GoogleBoolean? NonInteractionHit { get; set; }
+        [Beacon("ni")]
+        public bool? NonInteractionHit { get; set; }
 
         #endregion
 
@@ -150,8 +150,8 @@ namespace GoogleAnalyticsTracker.Core.TrackerParameters
         /// <remarks>Optional</remarks>
         /// <example>GoogleBoolean.True</example>
         /// </summary>                
-        [Beacon("je", false, true)]
-        public GoogleBoolean? JavaEnabled { get; set; }
+        [Beacon("je")]
+        public bool? JavaEnabled { get; set; }
 
         /// <summary>
         /// Specifies the flash version.

--- a/GoogleAnalyticsTracker.Core/TrackerParameters/GoogleBoolean.cs
+++ b/GoogleAnalyticsTracker.Core/TrackerParameters/GoogleBoolean.cs
@@ -1,8 +1,0 @@
-namespace GoogleAnalyticsTracker.Core.TrackerParameters
-{
-    public enum GoogleBoolean
-    {
-        True = 1,
-        False = 0
-    }
-}

--- a/GoogleAnalyticsTracker.Core/TrackerParameters/Interface/IExceptionParameters.cs
+++ b/GoogleAnalyticsTracker.Core/TrackerParameters/Interface/IExceptionParameters.cs
@@ -11,9 +11,9 @@ namespace GoogleAnalyticsTracker.Core.TrackerParameters.Interface
 
         /// <summary>
         /// Specifies whether the exception was fatal.
-        /// <remarks>Optional</remarks>
-        /// <example>0</example>
+        /// <remarks>Optional, null value means the exception is fatal.</remarks>
+        /// <example>false</example>
         /// </summary>  
-        GoogleBoolean IsFatal { get; set; }
+        bool? IsFatal { get; set; }
     }
 }

--- a/GoogleAnalyticsTracker.Core/TrackerParameters/Interface/IGeneralParameters.cs
+++ b/GoogleAnalyticsTracker.Core/TrackerParameters/Interface/IGeneralParameters.cs
@@ -24,7 +24,7 @@ namespace GoogleAnalyticsTracker.Core.TrackerParameters.Interface
         /// <remarks>Optional</remarks>
         /// <example>GoogleBoolean.True</example>
         /// </summary>        
-        GoogleBoolean? AnonymizeIp { get; set; }
+        bool? AnonymizeIp { get; set; }
 
         /// <summary>
         /// Used to collect offline / latent hits. 

--- a/GoogleAnalyticsTracker.Core/TrackerParameters/Interface/IHitParameters.cs
+++ b/GoogleAnalyticsTracker.Core/TrackerParameters/Interface/IHitParameters.cs
@@ -14,6 +14,6 @@ namespace GoogleAnalyticsTracker.Core.TrackerParameters.Interface
         /// <remarks>Optional</remarks>
         /// <example>GoogleBoolean.True</example>
         /// </summary>        
-        GoogleBoolean? NonInteractionHit { get; set; }
+        bool? NonInteractionHit { get; set; }
     }
 }

--- a/GoogleAnalyticsTracker.Core/TrackerParameters/Interface/ISystemInfoParameters.cs
+++ b/GoogleAnalyticsTracker.Core/TrackerParameters/Interface/ISystemInfoParameters.cs
@@ -42,7 +42,7 @@ namespace GoogleAnalyticsTracker.Core.TrackerParameters.Interface
         /// <remarks>Optional</remarks>
         /// <example>GoogleBoolean.True</example>
         /// </summary>        
-        GoogleBoolean? JavaEnabled { get; set; }
+        bool? JavaEnabled { get; set; }
 
         /// <summary>
         /// Specifies the flash version.

--- a/GoogleAnalyticsTracker.Core/TrackerParameters/UserTimings.cs
+++ b/GoogleAnalyticsTracker.Core/TrackerParameters/UserTimings.cs
@@ -6,7 +6,7 @@ namespace GoogleAnalyticsTracker.Core.TrackerParameters
     {
         public UserTimings()
         {
-            NonInteractionHit = GoogleBoolean.True;
+            NonInteractionHit = true;
         }
 
         #region Overrides of GeneralParameters


### PR DESCRIPTION
Or, maybe remove `GoogleBoolean` and change it for `bool`? The only change to use `bool` is `TrackerBase.GetParametersDictionary`.