### PR TITLE
TrackerBase.GetParametersDictionary convert to string with InvariantCulture

### DIFF
--- a/GoogleAnalyticsTracker.Core/TrackerBase.async.cs
+++ b/GoogleAnalyticsTracker.Core/TrackerBase.async.cs
@@ -45,10 +45,12 @@ namespace GoogleAnalyticsTracker.Core
                     value = p.GetMethod.Invoke(parameters, null);
                 }
 
-                if (value != null)
+                if (value == null)
                 {
-                    beaconList.Add(attr.Name, value.ToString());
+                    continue;
                 }
+                string strValue = Convert.ToString(value, CultureInfo.InvariantCulture);
+                beaconList.Add(attr.Name, strValue);
             }
 
             return beaconList.ToDictionary(key => key.Item1, value => value.Item2);

--- a/GoogleAnalyticsTracker.Core/TrackerBase.async.cs
+++ b/GoogleAnalyticsTracker.Core/TrackerBase.async.cs
@@ -49,8 +49,8 @@ namespace GoogleAnalyticsTracker.Core
                 {
                     continue;
                 }
-                string strValue = Convert.ToString(value, CultureInfo.InvariantCulture);
-                beaconList.Add(attr.Name, strValue);
+
+                beaconList.Add(attr.Name, Convert.ToString(value, CultureInfo.InvariantCulture));
             }
 
             return beaconList.ToDictionary(key => key.Item1, value => value.Item2);


### PR DESCRIPTION
Fix #135
`Convert.ToString` should correctly handle other number types, too.
Unit testing would be handy for such methods.