### PR TITLE
Fix TrackerBase.CreatePostWebRequest to async

### DIFF
--- a/GoogleAnalyticsTracker.Core/TrackerBase.cs
+++ b/GoogleAnalyticsTracker.Core/TrackerBase.cs
@@ -64,7 +64,7 @@ namespace GoogleAnalyticsTracker.Core
             {
                 request = UseHttpGet
                     ? CreateGetWebRequest(url, data.ToString())
-                    : CreatePostWebRequest(url, data.ToString());
+                    : await CreatePostWebRequestAsync(url, data.ToString());
 
                 if (!string.IsNullOrEmpty(userAgent))
                 {
@@ -119,12 +119,12 @@ namespace GoogleAnalyticsTracker.Core
             return WebRequest.CreateHttp(string.Format("{0}?{1}", url, data));
         }
 
-        private HttpWebRequest CreatePostWebRequest(string url, string data)
+        private async Task<HttpWebRequest> CreatePostWebRequestAsync(string url, string data)
         {
             var request = WebRequest.CreateHttp(url);
             request.Method = "POST";
             var dataBytes = Encoding.UTF8.GetBytes(data);
-            using (var stream = request.GetRequestStreamAsync().Result)
+            using (var stream = await request.GetRequestStreamAsync())
             {
                 stream.Write(dataBytes, 0, dataBytes.Length);
                 stream.Flush();


### PR DESCRIPTION
I've made a bug in #123 so the `TrackerBase.CreatePostWebRequest` was not really async and the `TrackerBase.TrackAsync` has waited for the connection to be opened. This change makes the `TrackerBase.TrackAsync` really async again.
Note: may be tested with `EndpointUrl = "http://httpstat.us/200?sleep=300000"`