### PR TITLE
Use Headers.TryAddWithoutValidation for User-Agent header 

### DIFF
--- a/GoogleAnalyticsTracker.Core/TrackerBase.cs
+++ b/GoogleAnalyticsTracker.Core/TrackerBase.cs
@@ -63,12 +63,11 @@ namespace GoogleAnalyticsTracker.Core
         private async Task<TrackingResult> RequestUrlAsync(string url, IDictionary<string, string> parameters, string userAgent)
         {
             // Create GET string
-            var data = new StringBuilder();
-            foreach (var parameter in parameters.OrderBy(p => p.Key, new BeaconComparer()))
-            {
+            var data = string.Join("&", parameters
+                .OrderBy(p => p.Key, new BeaconComparer())
                 // ReSharper disable once UseStringInterpolation
-                data.Append(string.Format("{0}={1}&", parameter.Key, Uri.EscapeDataString(parameter.Value)));
-            }
+                .Select(p => string.Format("{0}={1}", p.Key, Uri.EscapeDataString(p.Value)))
+            );
 
             // Build TrackingResult
             var returnValue = new TrackingResult

--- a/GoogleAnalyticsTracker.Core/TrackerBase.cs
+++ b/GoogleAnalyticsTracker.Core/TrackerBase.cs
@@ -74,7 +74,7 @@ namespace GoogleAnalyticsTracker.Core
             {
                 Url = url,
                 Parameters = parameters,
-                Query = data.ToString()
+                Query = data
             };
 
             // Create request
@@ -82,13 +82,13 @@ namespace GoogleAnalyticsTracker.Core
             try
             {
                 request = UseHttpGet
-                    ? CreateGetWebRequest(url, data.ToString())
-                    : CreatePostWebRequest(url, data.ToString());
+                    ? CreateGetWebRequest(url, data)
+                    : CreatePostWebRequest(url, data);
 
                 if (!string.IsNullOrEmpty(userAgent))
                 {
 
-                    request.Headers.Add("User-Agent", userAgent);
+                    request.Headers.TryAddWithoutValidation("User-Agent", userAgent);
                 }
             }
             catch (Exception ex)


### PR DESCRIPTION
.NET validates headers when you add them. See [this StackOverflow question](https://stackoverflow.com/questions/13198090/adding-httpclient-headers-generates-a-formatexception-with-some-values).
Normally this is nice, but in this library we are usually passing on the User-Agent header from the original request.
The problem with this is that .NET's validation may fail in cases that GoogleAnalytics would handle correctly.

When I enabled error logging of the Tracker, I got quite a number of these `System.FormatException`s in my log.

By using TryAddWithoutValidation we bypass this problematic validation.